### PR TITLE
Make theme customizable

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,6 +36,7 @@
   {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
     {{ template "_internal/google_analytics_async.html" . }}
   {{ end }}
+  {{ partial "header-include.html" . }}
 </head>
 <body class="{{if eq .Kind `page` }}single{{else}}list{{ if .IsHome }} home{{ end }}{{end}}">
   <header class="header">


### PR DESCRIPTION
This PR allows us to customize paper theme. In my use-case, I'd like to use a custom stylesheet.

The file name of `header-include.html` is from https://gohugo.io/templates/partials/#example-header-html. 