### PR TITLE
Add a way to change the date format with 'dateFormat' site param

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,7 +20,7 @@
    <p>{{ .Summary | plainify | htmlUnescape }}...</p>
   </section>
   <footer class="entry-footer">
-    <time >{{ .Date.Format "2006.1.2" }}</time>
+    <time>{{ .Date.Format (.Site.Params.dateFormat | default "2006.1.2") }}</time>
   </footer>
   <a class="entry-link" href="{{ .Permalink }}"></a>
 </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
     <div class="post-meta">
       {{- if or .Params.author .Site.Params.author -}}
       {{ .Params.author | default .Site.Params.author }} · {{ end }}
-      {{- .Date.Format "2006.1.2" -}}
+      {{- .Date.Format (.Site.Params.dateFormat | default "2006.1.2") -}}
     </div>
   </header>
   <div class="post-content">{{ .Content }}</div>


### PR DESCRIPTION
Previously it wasn't possible to change the date format and I think this an important thing to have in the theme because every country has different formats. After that PR, it will be possible to change the date format in the `config.toml` file like this:
```toml
[params]
dateFormat = "January 2, 2006"
```