### PR TITLE
Use global hugo function

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -28,7 +28,7 @@
     <link rel="apple-touch-icon" href="{{.Site.BaseURL}}img/apple-touch-icon.png">
     <link rel="icon" href="{{.Site.BaseURL}}img/favicon.ico">
     <!-- Generator -->
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     <!-- RSS -->
     <link rel="alternate" type="application/atom+xml" href="{{.Site.BaseURL}}index.xml" title="{{ .Site.Title }}">
     {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production") }}


### PR DESCRIPTION
When building the site with Hugo 0.55.5, I get the following warning: 
> Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.

Replacing .Hugo with hugo in header.html removes the warning.