### PR TITLE
Remove the marker of menu <ul> element to fix the style in Firefox

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -183,6 +183,7 @@ img {
   padding-bottom: 180px;
   text-align: center;
   background: #fff;
+  list-style: none;
 }
 .menu li + li {
   margin-top: 12px;


### PR DESCRIPTION
This is a problem in Firefox because Firefox displays markers(bullet points) of `<li>` element just before the inline contents of the elements. But Chrome displays them before the element, not depending on the content of the `<li>` element. So it wasn't visible on Chrome but it's in Firefox. This CSS change will remove that in Firefox too.
Before:
<img width="400" alt="Screen Shot 2019-05-04 at 7 43 26 PM" src="https://user-images.githubusercontent.com/466239/57183013-20c6bd00-6ea7-11e9-8c86-3b3a73611e8a.png">
After: 
<img width="400" alt="Screen Shot 2019-05-04 at 8 00 21 PM" src="https://user-images.githubusercontent.com/466239/57183025-51a6f200-6ea7-11e9-943a-bae61f46be32.png">
