### PR TITLE
Update style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -265,6 +265,7 @@ img {
   box-shadow: 0 8px 80px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   transition: box-shadow 0.2s;
+  overflow: hidden;
 }
 
 .post-entry:active {


### PR DESCRIPTION
移动端可能出现内容文本宽度溢出的情况，参照 `.first-entry` 在 `.post-entry` 中添加 `overflow: hidden` 。