### PR TITLE
Add support for custom styles and overrides.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,6 +24,7 @@
     <!-- Styles -->
     <link href="{{ "an-old-hope.min.css" | absURL }}" rel="stylesheet">
     <link href="{{ "style.css" | absURL }}" rel="stylesheet">
+    <link href="{{ "custom.css" | absURL }}" rel="stylesheet">
     <!-- Favicons -->
     <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | absURL }}">
     <link rel="icon" href="{{ "favicon.ico" | absURL }}">

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,0 +1,1 @@
+/* Place a custom css file in your own project to use this. */


### PR DESCRIPTION
The existing theme makes customization difficult, because in order to add or override styles you need to copy and paste the entire header partial so you can link your own stylesheets, or copy and paste the entire `style.css` file. This change adds an initially empty `custom.css` file that can be easily overridden to add custom styles or override existing ones.

As a use case, I've had to do this for my site to add syntax highlighting for code blocks following the official Hugo documentation.