### PR TITLE
Fix RSS links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,9 @@
     <!-- Generator -->
     {{- hugo.Generator }}
     <!-- RSS -->
-    <link rel="alternate" type="application/atom+xml" href="{{ "index.xml" | absURL }}" title="{{ .Site.Title }}">
+    {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end -}}
     <!-- Misc -->
     {{- if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production") }}
     {{- template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
Generated RSS file name can be changed in config:

```yaml
outputFormats:
  RSS:
    mediatype: 'application/rss'
    baseName: 'rss'
```

But template comtains "hardcoded" `index.xml` value. This changes improve this behavior