### PR TITLE
Add tags & categories list pages

### DIFF
--- a/layouts/partials/utils/limit-tree-posts.html
+++ b/layouts/partials/utils/limit-tree-posts.html
@@ -1,0 +1,29 @@
+{{- $ := index . "$" -}}
+{{- $pages := .pages -}}
+{{- $linkTarget := .linkTarget -}}
+
+{{ with $pages }}
+    {{ $rawPages := . }}
+    {{ $limit := -1 }}
+    {{ if isset $.Site.Params "limitpostslimit" }}
+        {{ $limit = $.Site.Params.limitPostsLimit }}
+    {{ end }}
+    {{ if ge $limit 0 }}
+        {{ $pages = $pages | first $limit -}}
+    {{ end }}
+
+    <ul class="list-posts">
+        {{ range $pages }}
+            <li>
+                <a href="{{ .RelPermalink }}" class="category-post">{{ (partial "utils/title.html" (dict "$" . "title" .LinkTitle)).htmlTitle }}</a>
+            </li>
+        {{ end }}
+        {{ if and (gt $limit 0) (gt (len $rawPages) $limit) }}
+            {{ with $linkTarget }}
+                <li>
+                    <a href="{{ $linkTarget.RelPermalink }}" class="category-post more">{{ i18n "readMore" }} »</a>
+                </li>
+            {{ end }}
+        {{ end }}
+    </ul>
+{{ end }}

--- a/layouts/partials/utils/markdownify.html
+++ b/layouts/partials/utils/markdownify.html
@@ -1,0 +1,30 @@
+{{- $ := index . "$" -}}
+{{- $Content := .raw -}}
+{{- $isContent := .isContent -}}
+
+<!-- New Markdown Syntax: Emphasis Point `..text..` -->
+{{- if $.Site.Params.enableEmphasisPoint -}}
+    {{- $regexPatternEmphasisPoint := `([^\.\x60])\.\.([^\.\s\n\/\\]+)\.\.([^\.\x60])` -}}
+    {{- $regexReplacementEmphasisPoint := `$1<em class="emphasis-point">$2</em>$3` -}}
+    {{- $Content = $Content | replaceRE $regexPatternEmphasisPoint $regexReplacementEmphasisPoint -}}
+{{- end -}}
+
+<!-- Markdownify -->
+{{- if not $isContent -}}
+    {{- $Content = $Content | markdownify -}}
+
+    <!-- Emojify -->
+    {{- if (fileExists "config.toml") -}}
+        {{- $enableEmoji := replaceRE `enableEmoji = (.+)` `$1` (delimit (readFile "config.toml" | findRE `enableEmoji = (.+)` | uniq) " ") -}}
+        {{- if eq $enableEmoji "true" -}}
+            {{- $Content = $Content | emojify -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+<!-- External Links -->
+{{- if $.Site.Params.hrefTargetBlank -}}
+    {{- $Content = replaceRE `(<a href="https?:[^"]+")` `$1 target="_blank" rel="noopener"` $Content -}}
+{{- end -}}
+
+{{- $Content | safeHTML -}}

--- a/layouts/partials/utils/title.html
+++ b/layouts/partials/utils/title.html
@@ -1,0 +1,29 @@
+{{- $ := index . "$" -}}
+{{- $htmlTitle := .title -}}
+<!-- Home -->
+{{- if eq $.Kind "home" -}}
+    {{- $htmlTitle = $htmlTitle | default $.Site.Title -}}
+<!-- Taxonomy -->
+{{- else if eq $.Kind "taxonomy" -}}
+    {{- $htmlTitle = $htmlTitle | default ($.Type | title) -}}
+<!-- Taxonomy Term -->
+{{- else if eq $.Kind "term" -}}
+    {{- $taxonomyTermTitle := $htmlTitle | default $.Data.Term | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" $.Path) "/")) " ") -}}
+    {{- with $.Site.GetPage (printf "/%s" $.Data.Plural) -}}
+        {{- $htmlTitle = printf "%s: %s" (.Title | default (.Type | title)) $taxonomyTermTitle -}}
+    {{- end -}}
+<!-- Section -->
+{{- else if eq $.Kind "section" -}}
+    {{- $htmlTitle = $htmlTitle | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" $.Path) "/")) " ") -}}
+{{- end -}}
+
+{{- $htmlTitle = partial "utils/markdownify.html" (dict "$" $ "raw" $htmlTitle "isContent" false) -}}
+
+{{- $rawTitle := $htmlTitle | plainify | htmlUnescape -}}
+
+{{- $title := $rawTitle -}}
+{{- if ne $.Kind "home" -}}
+    {{- $title = printf "%s | %s" $title $.Site.Title -}}
+{{- end -}}
+
+{{- return dict "rawTitle" $rawTitle "title" $title "htmlTitle" $htmlTitle -}}

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -1,0 +1,84 @@
+{{ partial "header.html" . }}
+
+<header class="page-header"><h1>{{ .Title | default (.Type | title) }}</h1></header>
+<div class="tree">
+	{{ .Scratch.Delete "categories" }}
+	{{ range $.Site.RegularPages }}
+		{{ with .Param "categories" }}
+			{{ $.Scratch.Delete "category" }}
+			{{ range $index, $category := . }}
+				{{ $category := (printf `/%s` ($category | urlize)) }}
+				{{ $.Scratch.Add "category" $category }}
+				{{ $.Scratch.Add "categories" (slice ($.Scratch.Get "category")) }}
+			{{ end }}
+		{{ end }}
+	{{ end }}
+	{{ $categories := uniq (.Scratch.Get "categories") | sort }}
+
+	<ul class="list-categories">
+		{{ range $index, $value := $categories }}
+			{{ $categoryTerms := (split (strings.TrimPrefix "/" .) "/") }}
+			{{ $depth := (len $categoryTerms) }}
+			{{ $lastTerm := (delimit (last 1 $categoryTerms) " ") }}
+			{{ $url := urls.Parse $lastTerm }}
+			{{ $path := $url.Path }}
+
+			{{ with $.Site.GetPage (printf `/categories/%s` $path) }}
+				{{ $linkTarget := . }}
+
+				{{ $depthPrev := 0 }}
+				{{ if ge $index 1 }}
+					{{ $categoryPrev := index $categories (sub $index 1) }}
+					{{ $depthPrev = len (split (strings.TrimPrefix "/" $categoryPrev) "/") }}
+				{{ end }}
+
+				{{ $depthNext := 0 }}
+				{{ if lt $index (sub (len $categories) 1) }}
+					{{ $categoryNext := index $categories (add $index 1) }}
+					{{ $depthNext = len (split (strings.TrimPrefix "/" $categoryNext) "/") }}
+				{{ end }}
+
+				{{ if or (le $depth $depthPrev) (eq $index 0) }}
+					<li>
+				{{ end }}
+				{{ if and (gt $depth $depthPrev) (ne $index 0) }}
+					<ul class="list-categories"><li>
+				{{ end }}
+
+				<a href="{{ .RelPermalink }}" class="category-item">{{ .LinkTitle | default .Data.Term | default $path }}</a>
+				<span class="category-count">{{ printf "(%d)" (len .Data.category) }}</span>
+
+				{{ $.Scratch.Delete "pages" }}
+				{{ range $.Site.RegularPages }}
+					{{ $page := . }}
+					{{ with .Param "categories" }}
+						{{ $.Scratch.Delete "category" }}
+						{{ range . }}
+							{{ $category := (printf `/%s` (. | urlize)) }}
+							{{ $.Scratch.Add "category" $category }}
+						{{ end }}
+						{{ $category := $.Scratch.Get "category" }}
+						{{ if eq $value $category }}
+							{{ $.Scratch.Add "pages" (slice $page) }}
+						{{ end }}
+					{{ end }}
+				{{ end }}
+				{{ $pages := $.Scratch.Get "pages" }}
+				{{ partial "utils/limit-tree-posts.html" (dict "$" $ "pages" $pages "linkTarget" $linkTarget) }}
+
+				{{ if and (gt $depth $depthNext) (ne $index (sub (len $categories) 1)) }}
+					{{ range seq (sub $depth $depthNext) }}
+						{{ if le . (sub $depth $depthNext) }}
+							</li></ul>
+						{{ end }}
+					{{ end }}
+				{{ end }}
+				{{ if ge $depth $depthNext }}
+					</li>
+				{{ end }}
+			{{ end }}
+		{{ end }}
+	</ul>
+</div>
+
+{{ partial "footer.html" . }}

--- a/layouts/taxonomy/tag.terms.html
+++ b/layouts/taxonomy/tag.terms.html
@@ -1,0 +1,17 @@
+{{ partial "header.html" . }}
+
+<header class="page-header"><h1>{{ .Title | default (.Type | title) }}</h1></header>
+{{ if ne (len $.Site.Taxonomies.tags) 0 }}
+	<ul class="tags-list">
+	{{ range $index, $tag := $.Site.Taxonomies.tags.ByCount }}
+		<li class="tag">
+		{{ with $.Site.GetPage (printf "/tags/%s" $tag.Name) }}
+		<a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Data.Term | default $tag.Name }}</a>
+		{{ end }}
+		<span class="tag-count">({{ $tag.Count }})</span>
+		</li>
+	{{ end }}
+	</ul>
+{{ end }}
+
+{{ partial "footer.html" . }}

--- a/static/style.css
+++ b/static/style.css
@@ -526,3 +526,77 @@ img {
   font-size: 160px;
   font-weight: 700;
 }
+<<<<<<< HEAD
+
+/* Categories list page
+=======
+/* Categories
+>>>>>>> 1aff209... add categories page
+-------------------------------------------------- */
+.tree {
+  overflow: auto hidden;
+  white-space: nowrap;
+}
+
+.tree ul {
+  padding-left: 2.4em;
+  list-style-type: none;
+}
+
+.tree > ul {
+  padding: 0;
+}
+
+
+.list-categories > li {
+  position: relative;
+}
+
+.list-categories > li::before {
+  content: " ";
+  position: absolute;
+  top: 2.4em;
+  left: 0.1em;
+  width: 0.2em;
+  height: calc(100% - 2.8em);
+  background: var(--tertiary);
+}
+
+.category-item {
+  color: var(--primary);
+  font-size: 1.2em;
+  box-shadow: 0 1px 0 var(--primary);
+}
+
+.category-count {
+  color: var(--secondary);
+}
+
+.category-post:hover {
+  color: var(--secondary);
+}
+/* Tags list page
+-------------------------------------------------- */
+ul.tags-list {
+  overflow: hidden;
+  white-space: nowrap;
+  list-style-type: none;
+}
+
+ul.tags-list li.tag {
+  font-size: 1.2em;
+}
+
+ul.tags-list li.tag a {
+  text-decoration: none;
+  color: var(--primary);
+  box-shadow: 0 1px 0 var(--primary);;
+}
+
+ul.tags-list li.tag a:hover {
+  cursor: pointer;
+}
+
+ul.tags-list li.tag span.tag-count {
+  color: var(--secondary);
+}


### PR DESCRIPTION
This adds special list pages for the `tag` and `category` taxonomies.

The category page looks like this:
![image](https://user-images.githubusercontent.com/63574107/91082481-935c2e80-e5fd-11ea-93ad-97c930856727.png)

And the tags page looks like this:
![image](https://user-images.githubusercontent.com/63574107/91082537-a8d15880-e5fd-11ea-983c-6ac8ffd553d5.png)

The parentheses next to the tags/categories are the number of pages in that term.