### PR TITLE
Fixed double titles on homepage

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Title -->
-    <title>{{ if .Title }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
+    <title>{{ if not .IsHome }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
     <!-- Meta -->
     {{- if eq .Kind "page" }}
     <meta name="description" content="{{ .Summary }}">


### PR DESCRIPTION
This code `{{ if .Title }}{{ .Title }} - {{ end }}` also reads the site title so there is double titles on the homepage.

![screenshots-2021-03-26-07-44-24](https://user-images.githubusercontent.com/57146067/112564196-6aa74c00-8e0d-11eb-9a05-aea642d92e87.jpg)

I just trying to fix it. Please, check my pull request and let me know if something goes wrong with my configuration.