### PR TITLE
add-google-analytics-v4-support

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -61,6 +61,8 @@
   <!---->
   {{ template "_internal/google_analytics_async.html" . }}
   <!---->
+  {{ template "_internal/google_analytics.html" . }}
+  <!---->
   {{ template "_internal/google_news.html" . }}
   <!---->
   {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
I've recently moved to this theme and love this beautiful theme.

I noticed that my Google Analytics tags(v4) are not be applied. This pull request is to fix that.

FYI:

[https://gohugo.io/templates/internal/#use-the-google-analytics-template](https://gohugo.io/templates/internal/#use-the-google-analytics-template)

> When using Google Analytics v4 use _internal/google_analytics.html.
