### PR TITLE
Demo site: correct rendering of subscript, superscript and other raw html markup

### DIFF
--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 /public
 /themes
 .DS_Store
+.hugo_build.lock

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,12 @@ title = "Paper"
   instagram = 'nan.xiaobei'
 # ------------------------------
 
+# needed to  render raw HTML (e.g. <sub>, <sup>, <kbd>, <mark>)
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+
 [menu]
 
   [[menu.main]]


### PR DESCRIPTION
**Demo site, [Markdown Syntax Guide](https://hugo-paper.vercel.app/post/markdown-syntax/):**

Last chapter `Other Elements — abbr, sub, sup, kbd, mark`

Terms like H<sub>2</sub>O are rendered incorrectly since by default, hugo's default renderer `goldmark` scrubs raw html tags for security reasons (see hugo's [documentation](https://gohugo.io/getting-started/configuration-markup#goldmark) on this topic). This PR corrects this incorrect rendering.

