### PR TITLE
Date is hidden when none is provided

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,9 @@
 <article class="post-single">
   <header class="post-title">
     <p>
+      {{ if .Date }}
       <time>{{ .Date | time.Format ":date_medium" }}</time>
+      {{ end }}
       {{ if or .Params.Author site.Author.name }}
       <span>{{ .Params.Author | default site.Author.name }}</span>
       {{ end }}


### PR DESCRIPTION
Static pages within a blog might not have a publish date. For example an "about" page. With this tweak, one can just omit the date field in the page's metadata and the output won't show the default date.