### PR TITLE
Fix preload dark icon

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,10 +33,14 @@
   {{ end }}
 
   <!-- Preload -->
+  {{ $dark_icon := "theme.png" }}
+  {{ if site.Params.monoDarkIcon }}
+    {{ $dark_icon := "theme.svg" }}
+  {{ end }}
   <link
     rel="preload"
     as="image"
-    href="{{ `theme.{{ if site.Params.monoDarkIcon }}svg{{ else }}png{{ end }}` | absURL }}"
+    href="{{ $dark_icon | absURL }}"
   />
 
   {{ $avatar_url := $.Scratch.Get "avatar_url" }}


### PR DESCRIPTION
In the head of the page, the icons for the dark mode are incorrectly preloaded, the request is `https://hugo-paper.vercel.app/theme.{{ if site.Params.monoDarkIcon }}svg{{ else }}png{{ end }}` instead of `https://hugo-paper.vercel.app/theme.png` or `https://hugo-paper.vercel.app/theme.svg`.

Open the console on the [demo](https://hugo-paper.vercel.app/) to see the 404 request.