### PR TITLE
Add rel="me" param to social links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -84,6 +84,7 @@
         style="--url: url(./{{ . }}.svg)"
         href="{{ if eq . `rss` }} {{ `index.xml` | absURL }} {{ else if eq . `mastodon` }} {{ site.Params.Get . }} {{ else }} https://{{ . }}.com/{{ site.Params.Get . }} {{ end }}"
         target="_blank"
+        {{ if ne . `rss` }}rel="me"{{ end }}
       ></a>
       {{ end }}<!---->
     </nav>


### PR DESCRIPTION
Adding rel="me" to social links for domain identification [https://microformats.org/wiki/rel-me](https://microformats.org/wiki/rel-me)
Mostly for [Mastodon](https://joinmastodon.org/) domain verification purposes.