### PR TITLE
Update single.html - article nav order

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -33,17 +33,19 @@
   {{ end }}
 
   <!-- Post Nav -->
-  {{ $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}<!---->
+  {{ $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
+  <!---->
   {{ if and (gt (len $pages) 1) (in $pages . ) }}
   <nav class="mt-24 flex rounded-lg bg-black/[3%] text-lg dark:bg-white/[8%]">
-    {{ with $pages.Next . }}
+    {{ with $pages.Prev . }}
     <a
       class="flex w-1/2 items-center rounded-l-md p-6 pr-3 no-underline hover:bg-black/[2%]"
       href="{{ .Permalink }}"
       ><span class="mr-1.5">←</span><span>{{ .Name }}</span></a
     >
-    {{ end }}<!---->
-    {{ with $pages.Prev . }}
+    {{ end }}
+    <!---->
+    {{ with $pages.Next . }}
     <a
       class="ml-auto flex w-1/2 items-center justify-end rounded-r-md p-6 pl-3 no-underline hover:bg-black/[2%]"
       href="{{ .Permalink }}"


### PR DESCRIPTION
In my opinion the article navigation for next and previous posts were around the wrong way. 

I believe the next post should be on the right side of the page and the previous post on the left side of the page.