### PR TITLE
fix title's link when there is no baseURL in config file

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
   <div class="relative z-50 mr-auto flex items-center">
     <a
       class="-translate-x-[1px] -translate-y-0.5 text-3xl font-bold"
-      href="{{ `` | absURL }}"
+      href="{{ `/` | absURL }}"
       >{{ site.Title }}</a
     >
     <a


### PR DESCRIPTION
when the config file doesn't provide baseURL, there would be a bug that title's link is not home page's link.