### PR TITLE
Update head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -83,8 +83,6 @@
   <!---->
   {{ template "_internal/google_analytics.html" . }}
   <!---->
-  {{ template "_internal/google_news.html" . }}
-  <!---->
   {{ template "_internal/opengraph.html" . }}
   <!---->
   {{ template "_internal/schema.html" . }}


### PR DESCRIPTION
Fixes #157 since google_news internal template was removed in version 0.111.0 of Hugo.