### PR TITLE
Fix theme.svg preload

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,7 +44,7 @@
 
   <!-- Preload -->
   {{ $dark_icon := "theme.png" }} {{ if site.Params.monoDarkIcon }} {{
-  $dark_icon := "theme.svg" }} {{ end }}
+  $dark_icon = "theme.svg" }} {{ end }}
   <link rel="preload" as="image" href="{{ $dark_icon | absURL }}" />
 
   {{ $avatar_url := $.Scratch.Get "avatar_url" }}


### PR DESCRIPTION
Hey! Thank you for this theme!

I was looking into the code and I realized that the `:=` operator will create a new variable instead of overriding the previous one.

So here is the fix :tada: 
