### PR TITLE
update href of header title

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
   <div class="relative z-50 mr-auto flex items-center">
     <a
       class="-translate-x-[1px] -translate-y-[1px] text-2xl font-semibold"
-      href="{{ `` | absURL }}"
+      href="{{ `/` | absURL }}"
       >{{ site.Title }}</a
     >
     <div


### PR DESCRIPTION
The default value now is empty. If I don't set the ```baseurl```, this title will not jump to the homepage. 