### PR TITLE
fix[README.md]: Correct hugo command of use as module secion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For more information, please read the [official guide](https://gohugo.io/getting
 Add paper theme ad dependency of your site:
 
 ```bash
-hugo mod init github.com/nanxiaobei/hugo-paper
+hugo mod init github.com/<your_user>/<your_project>
 ```
 
 Open `config.toml`(or `hugo.toml`), remove the `theme` line (if present), add `module` section to the bottom of the file:


### PR DESCRIPTION
Hugo docs means user need initialize go mod system before using modules,  
so I think `hugo mod init` comamnd with *this* repo will mislead theme users.
