### PR TITLE
Add configurable KaTeX location

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ disqusShortname = 'YOUR_DISQUS_SHORTNAME'   # use disqus comments
   monoDarkIcon = true                       # show monochrome dark mode icon
   gravatarCdn = 'GRAVATAR_CDN_LINK'         # e.g. 'https://cdn.v2ex.com/gravatar/'
   math = true                               # enable KaTeX math typesetting globally
+  local_katex = false                       # use local KaTeX js/css instead of CDN
   graphCommentId = "YOUR_GRAPH_COMMENT_ID"  # use graph comment (disqus alternative)
 
   # giscus

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ disqusShortname = 'YOUR_DISQUS_SHORTNAME'   # use disqus comments
   monoDarkIcon = true                       # show monochrome dark mode icon
   gravatarCdn = 'GRAVATAR_CDN_LINK'         # e.g. 'https://cdn.v2ex.com/gravatar/'
   math = true                               # enable KaTeX math typesetting globally
-  local_katex = false                       # use local KaTeX js/css instead of CDN
+  localKatex = false                        # use local KaTeX js/css instead of CDN
   graphCommentId = "YOUR_GRAPH_COMMENT_ID"  # use graph comment (disqus alternative)
 
   # giscus

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,4 +1,4 @@
-{{ if site.Params.local_katex }}
+{{ if site.Params.localKatex }}
 <link rel="stylesheet" href="{{ "katex.min.css" | relURL }}"/>
 <script defer src="{{ "katex.min.js" | relURL }}"></script>
 <script defer src="{{ "auto-render.min.js" | relURL }}"></script>

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,3 +1,8 @@
+{{ if site.Params.local_katex }}
+<link rel="stylesheet" href="{{ "katex.min.css" | relURL }}"/>
+<script defer src="{{ "katex.min.js" | relURL }}"></script>
+<script defer src="{{ "auto-render.min.js" | relURL }}"></script>
+{{ else }}
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/katex.min.css"
@@ -16,6 +21,7 @@
   integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05"
   crossorigin="anonymous"
 ></script>
+{{ end }}
 
 <script>
   document.addEventListener('DOMContentLoaded', () =>


### PR DESCRIPTION
I noticed the theme was using a CDN for the KaTeX library. In context of security it may be preferable to have those libraries locally, from the same domain. I'm open to change this pull-request to work in another way (different variable name, another way of achieving the same result, etc.) if needed.

The patch adds a local_katex variable, which if set, will load the JS/CSS from the base URL. The user of the theme needs to place these files in the page source `static/` folder (so it's up to the owner of the site to control the version/files).