### PR TITLE
.Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -58,10 +58,10 @@
   {{ end }}
 
   <!-- Disqus -->
-  {{ if and site.DisqusShortname (not (eq .Params.comments false)) }}
+  {{ if and .Site.Config.Services.Disqus.Shortname (not (eq .Params.comments false)) }}
   <div class="mt-24" id="disqus_thread"></div>
   <script>
-    const disqusShortname = '{{ site.DisqusShortname }}';
+    const disqusShortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
     const script = document.createElement('script');
     script.src = 'https://' + disqusShortname + '.disqus.com/embed.js';
     script.setAttribute('data-timestamp', +new Date());


### PR DESCRIPTION
.Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.