### PR TITLE
Customization of copyright in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,8 +2,12 @@
   class="mx-auto flex h-[4.5rem] max-w-[--w] items-center px-8 text-xs uppercase tracking-wider opacity-60"
 >
   <div class="mr-auto">
+  {{if site.Copyright}}
+    {{site.Copyright}}
+  {{else}}
     &copy; {{ now.Year }}
     <a class="link" href="{{ `` | absURL }}">{{ site.Title }}</a>
+  {{endif}}
   </div>
   <a class="link mx-6" href="https://gohugo.io/" rel="noopener" target="_blank"
     >powered by hugo️️</a


### PR DESCRIPTION
`hugo.toml` supports a "copyright" option, but theme doesn't.

This PR adds support for custom copyright in the footer. If copyright is not specified, the default version (which is hardcoded now) is used ("© (current year) (site title)") 