### PR TITLE
Uncollapse templates that want spaces

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
 >
   <div class="mr-auto">
     {{- if site.Copyright -}} {{- site.Copyright -}} {{- else -}} &copy; {{-
-    now.Year -}}
+    now.Year }}
     <a class="link" href="{{- `` | absURL -}}">{{- site.Title -}}</a>
     {{- end -}}
   </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
 
   <!-- title -->
   <title>
-    {{- if not .IsHome -}}{{- .Title -}} - {{- end -}}{{- site.Title -}}
+    {{- if not .IsHome -}}{{- .Title }} - {{ end -}}{{- site.Title -}}
   </title>
 
   <!-- meta -->


### PR DESCRIPTION
Hi @nanxiaobei - thank you so much for this beautiful Hugo theme!

I noticed one issue with it when using it, which is that the titles collapse spaces between the page title and the site title, and the same in the footer in the copyright message.

You can see in this screenshot how the title looks on your demo site compared with mine:

![Screenshot From 2025-04-18 09-15-26](https://github.com/user-attachments/assets/341870cc-0a30-4e14-9a90-fcb58a278b91)

And the fixed version of the footer on mine:

![Screenshot From 2025-04-18 09-15-51](https://github.com/user-attachments/assets/f6242486-a79b-47e6-bce9-ef80d81e4187)

The fix is to remove the collapsing `-` from a couple of the partials. I wondered if you might consider this PR to bring these changes upstream.

Thanks so much!