### PR TITLE
Add css checksum to the url to enable cache busting

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,8 +34,8 @@
   <!---->
   {{- $custom := resources.Get "custom.css" -}}
   <!---->
-  {{- $css := slice $main $custom | resources.Concat "main.css" | minify -}}
-  <link rel="preload stylesheet" as="style" href="{{- $css.Permalink -}}" />
+  {{- $css := slice $main $custom | resources.Concat "main.css" | minify | fingerprint -}}
+  <link rel="preload stylesheet" as="style" href="{{- $css.Permalink -}}" integrity="{{ $css.Data.Integrity }}" />
 
   <!-- dark icon -->
   {{- $dark_icon := "theme.png" -}}


### PR DESCRIPTION
The PR adds the css file checksum (fingerprint) to the URL so when its content changes, the browser invalidates the cache and requests the new file.

example `main.min.1e0a19315f49449bf09109d685c457aeaede6b48942442fa2b52c364d680db4c.css`