### PR TITLE
.Site.LanguageCode was deprecated in Hugo v0.158.0 and will be remove…

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -2,7 +2,7 @@ baseURL = "https://hugo-paper.vercel.app/"
 title = "Paper"
 author = "Steve Francia"
 copyright = "© 2025, lee.so"
-languageCode = "en"
+locale = "en"
 DefaultContentLanguage = "en"
 enableInlineShortcodes = true
 # prevent build failures when using Hugo's Instagram shortcode due to deprecated Instagram API.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
 <html
   class="not-ready lg:text-base"
   style="--bg: {{- $bg_color -}}"
-  lang="{{- or site.LanguageCode site.Language.Lang -}}"
+  lang="{{- .Site.Language.Locale -}}"
   dir="{{- if site.Params.direction -}}{{- site.Params.direction -}}{{- else -}}ltr{{- end -}}"
 >
   {{- partial "head.html" . -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,7 +9,7 @@
       {{- if .Date -}}
       <time>{{- .Date | time.Format ":date_medium" -}}</time>
       {{- end -}}<!---->
-      {{- $single_author := or .Params.Author site.Author.name -}}
+      {{- $single_author := or .Params.author site.Params.author -}}
       <!---->
       {{- if $single_author -}}
       <span class="mx-1">&middot;</span>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,8 @@
   <meta name="theme-color" />
 
   <!-- author -->
-  {{- $site_author := or site.Params.Author.name site.Params.name site.Title -}}
+  {{- $site_author := or .Params.author site.Params.author site.Title -}}
+
   <!---->
   {{- if eq .Kind "page" -}}
   <meta name="description" content="{{- .Summary -}}" />


### PR DESCRIPTION
`.Site.LanguageCode` was deprecated in Hugo v0.158.0 and will be removed in a future release. Use `.Site.Language.Locale` instead.