### PR TITLE
deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
 <html
   class="not-ready lg:text-base"
   style="--bg: {{- $bg_color -}}"
-  lang="{{- or site.LanguageCode site.Language.Lang -}}"
+  lang="{{- or .Site.Language.Locale site.Language.Lang -}}"
   dir="{{- if site.Params.direction -}}{{- site.Params.direction -}}{{- else -}}ltr{{- end -}}"
 >
   {{- partial "head.html" . -}}


### PR DESCRIPTION
deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead